### PR TITLE
chore(renovate): add automerge settings

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,14 @@
 {
   "extends": ["config:js-lib", "group:definitelyTyped", ":maintainLockFilesWeekly"],
-  "postUpdateOptions": ["yarnDedupeHighest"]
+  "postUpdateOptions": ["yarnDedupeHighest"],
+  "packageRules": [
+    {
+      "depTypeList": ["devDependencies"],
+      "automerge": true
+    },
+    {
+      "packagePatterns": ["^rollup", "^@rollup/"],
+      "automerge": false
+    }
+  ]
 }


### PR DESCRIPTION
Add `automerge` to `devDependencies` in Renovate configuration.
However, the package related to rollup was excluded because of the influence on the bundle.