### PR TITLE
fix: fix checksum path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - v1-dependencies-{{ arch }}-{{ checksum ".node-version" }}-{{ checksum "yarn.lock" }}
+            - v1-dependencies-{{ arch }}-{{ checksum "../.node-version" }}-{{ checksum "yarn.lock" }}
             - v1-dependencies-{{ arch }}
             - v1-dependencies-
       - run:
@@ -23,7 +23,7 @@ commands:
       - save_cache:
           paths:
             - node_modules
-          key: v1-dependencies-{{ arch }}-{{ checksum ".node-version" }}-{{ checksum "yarn.lock" }}
+          key: v1-dependencies-{{ arch }}-{{ checksum "../.node-version" }}-{{ checksum "yarn.lock" }}
 
 jobs:
   test:


### PR DESCRIPTION
resolve the following error 

> error computing cache key: template: cacheKey:1:30: executing "cacheKey" at <checksum ".node-version">: error calling checksum: open /home/circleci/timetree-sdk-js/web-api/.node-version: no such file or directory

